### PR TITLE
事务锁

### DIFF
--- a/internal/app/context/context.go
+++ b/internal/app/context/context.go
@@ -6,6 +6,7 @@ import (
 
 // 定义全局上下文中的键
 type (
+	lockCtx    struct{}
 	transCtx   struct{}
 	userIDCtx  struct{}
 	traceIDCtx struct{}
@@ -20,6 +21,17 @@ func NewTrans(ctx context.Context, trans interface{}) context.Context {
 func FromTrans(ctx context.Context) (interface{}, bool) {
 	v := ctx.Value(transCtx{})
 	return v, v != nil
+}
+
+// NewLock 是否加锁
+func NewLock(ctx context.Context, lock bool) context.Context {
+	return context.WithValue(ctx, lockCtx{}, lock)
+}
+
+// IsForUpdate 从上下文中判断是否 FOR UPDATE
+func IsForUpdate(ctx context.Context) bool {
+	v := ctx.Value(lockCtx{})
+	return v.(bool) == true
 }
 
 // NewUserID 创建用户ID的上下文

--- a/internal/app/model/impl/gorm/gorm.go
+++ b/internal/app/model/impl/gorm/gorm.go
@@ -15,7 +15,9 @@ func SetTablePrefix(prefix string) {
 
 // AutoMigrate 自动映射数据表
 func AutoMigrate(db *gormplus.DB) error {
-	return db.AutoMigrate(
+	return db.
+		Set("gorm:table_options", "ENGINE=InnoDB").
+		AutoMigrate(
 		new(entity.Demo),
 		new(entity.User),
 		new(entity.UserRole),

--- a/internal/app/model/impl/gorm/internal/entity/entity.go
+++ b/internal/app/model/impl/gorm/internal/entity/entity.go
@@ -45,7 +45,7 @@ func getDB(ctx context.Context, defDB *gormplus.DB) *gormplus.DB {
 	if ok {
 		db, ok := trans.(*gormplus.DB)
 		if ok {
-			return db
+			return db.ForUpdate()
 		}
 	}
 	return defDB

--- a/internal/app/model/impl/gorm/internal/entity/entity.go
+++ b/internal/app/model/impl/gorm/internal/entity/entity.go
@@ -45,7 +45,12 @@ func getDB(ctx context.Context, defDB *gormplus.DB) *gormplus.DB {
 	if ok {
 		db, ok := trans.(*gormplus.DB)
 		if ok {
-			return db.ForUpdate()
+			lock := icontext.IsForUpdate(ctx)
+			if lock {
+				return db.ForUpdate()
+			} else {
+				return db
+			}
 		}
 	}
 	return defDB

--- a/pkg/gormplus/gorm.go
+++ b/pkg/gormplus/gorm.go
@@ -82,6 +82,11 @@ func (d *DB) FindPage(db *gorm.DB, pageIndex, pageSize int, out interface{}) (in
 	return count, nil
 }
 
+// ForUpdate 事务锁
+func (d *DB) ForUpdate() *DB {
+	return Wrap(d.Set("gorm:query_option", "FOR UPDATE"))
+}
+
 // FindOne 查询单条数据
 func (d *DB) FindOne(db *gorm.DB, out interface{}) (bool, error) {
 	result := db.First(out)


### PR DESCRIPTION
1、数据迁移默认创建表类型为InnoDB
2、在事务中的SELECT查询添加FOR UPDATE