### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ $ gin-admin-cli new -m -d ~/go/src/gin-admin -p gin-admin
 > 可自动监听文件变化
 
 ```bash
-$ go get -v github.com/cosmtrek/air/cmd/air
+$ go get -u github.com/cosmtrek/air
 $ cd ~/go/src/gin-admin
+$ go mod download
 $ air
 ```
 


### PR DESCRIPTION
修复air安装命令错误，修复安装后直接运行air后会报错，需要先执行go mod download下载依赖