### PR TITLE
fix auth pkg degraded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: start
 build:
 	@go build -ldflags "-w -s" -o $(SERVER_BIN) ./cmd/${APP}
 
-start: 
+start:
 	go run cmd/${APP}/main.go web -c ./configs/config.toml -m ./configs/model.conf --menu ./configs/menu.yaml
 
 swagger:
@@ -22,7 +22,7 @@ wire:
 	wire gen ./internal/app/injector
 
 test:
-	@go test -v ./internal/app/test
+	@go test -v $(shell go list ./...)
 
 clean:
 	rm -rf data release $(SERVER_BIN) ./internal/app/test/data ./cmd/${APP}/data

--- a/pkg/auth/jwtauth/auth.go
+++ b/pkg/auth/jwtauth/auth.go
@@ -153,7 +153,7 @@ func (a *JWTAuth) ParseUserID(ctx context.Context, tokenString string) (string, 
 	err = a.callStore(func(store Storer) error {
 		if exists, err := store.Check(ctx, tokenString); err != nil {
 			return err
-		} else if !exists {
+		} else if exists {
 			return auth.ErrInvalidToken
 		}
 		return nil


### PR DESCRIPTION
# 我修改了以下内容
- https://github.com/LyricTian/gin-admin/pull/80 这个提交应是错误的，store应只保存Blacklisting JWT，auth的测试代码也发生了错误
```
=== RUN   TestAuth
    TestAuth: auth_test.go:26: 
                Error Trace:    auth_test.go:26
                Error:          Expected nil, but got: &errors.errorString{s:"invalid token"}
                Test:           TestAuth
    TestAuth: auth_test.go:27: 
                Error Trace:    auth_test.go:27
                Error:          Not equal: 
                                expected: "test"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -test
                                +
                Test:           TestAuth
    TestAuth: auth_test.go:33: 
                Error Trace:    auth_test.go:33
                Error:          Expected value not to be nil.
                Test:           TestAuth
    TestAuth: auth_test.go:34: 
                Error Trace:    auth_test.go:34
                Error:          An error is expected but got nil.
                Test:           TestAuth
    TestAuth: auth_test.go:35: 
                Error Trace:    auth_test.go:35
                Error:          Should be empty, but was test
                Test:           TestAuth
```
+ go test测试了所有的go pkg