### PR TITLE
chore: 🤖 make swagger add --parseDependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ start:
 	go run -ldflags "-X main.VERSION=$(RELEASE_TAG)" ./cmd/${APP}/main.go web -c ./configs/config.toml -m ./configs/model.conf --menu ./configs/menu.yaml
 
 swagger:
-	swag init --generalInfo ./cmd/${APP}/main.go --output ./internal/app/swagger
+	swag init --parseDependency --generalInfo ./cmd/${APP}/main.go --output ./internal/app/swagger
 
 wire:
 	wire gen ./internal/app


### PR DESCRIPTION
swag > 1.67 version need add --parseDependency
https://github.com/swaggo/swag/issues/817