### PR TITLE
fix(rbac/biz/menu.biz.go)：修复Create方法中的变量名错误

### DIFF
--- a/internal/mods/rbac/biz/menu.biz.go
+++ b/internal/mods/rbac/biz/menu.biz.go
@@ -315,7 +315,7 @@ func (a *Menu) Create(ctx context.Context, formItem *schema.MenuForm) (*schema.M
 		menu.ParentPath = parent.ParentPath + parent.ID + util.TreePathDelimiter
 	}
 
-	if exists, err := a.MenuDAL.ExistsCodeByParentID(ctx, menu.Code, menu.ParentID); err != nil {
+	if exists, err := a.MenuDAL.ExistsCodeByParentID(ctx, formItem.Code, formItem.ParentID); err != nil {
 		return nil, err
 	} else if exists {
 		return nil, errors.BadRequest("", "Menu code already exists at the same level")


### PR DESCRIPTION
在Create方法中，修复了变量名错误，将menu.Code和menu.ParentID替换为formItem.Code和formItem.ParentID。这样可以确保在检查菜单代码是否已经存在时使用正确的表单项数据。