### PR TITLE
构建(http.go, auth.go)：添加RootID字段到AuthConfig结构体

### DIFF
--- a/internal/bootstrap/http.go
+++ b/internal/bootstrap/http.go
@@ -143,6 +143,7 @@ func useHTTPMiddlewares(_ context.Context, e *gin.Engine, injector *wirex.Inject
 		AllowedPathPrefixes: allowedPrefixes,
 		SkippedPathPrefixes: config.C.Middleware.Auth.SkippedPathPrefixes,
 		ParseUserID:         injector.M.RBAC.LoginAPI.LoginBIZ.ParseUserID,
+		RootID:              config.C.General.Root.ID,
 	}))
 
 	e.Use(middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 type AuthConfig struct {
 	AllowedPathPrefixes []string
 	SkippedPathPrefixes []string
+	RootID              string
 	Skipper             func(c *gin.Context) bool
 	ParseUserID         func(c *gin.Context) (string, error)
 }
@@ -30,6 +31,9 @@ func AuthWithConfig(config AuthConfig) gin.HandlerFunc {
 
 		ctx := util.NewUserID(c.Request.Context(), userID)
 		ctx = logging.NewUserID(ctx, userID)
+		if userID == config.RootID {
+			ctx = util.NewIsRootUser(ctx)
+		}
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}


### PR DESCRIPTION
修复在 config.C.Middleware.Auth.Disable  为 true 时只设置了用户 ID 没有设置上下文导致接口提示用户不存在的 bug。

复现流程设置 config.C.Middleware.Auth.Disable = true
重新登陆 root 账号
访问 /api/v1/current/user