### PR TITLE
为数据库添加 PrepareStmt 配置选项

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,7 @@ type Storage struct {
 		MaxIdleConns int    `default:"50"`               // connections
 		TablePrefix  string `default:""`
 		AutoMigrate  bool
+		PrepareStmt  bool
 		Resolver     []struct {
 			DBType   string   // sqlite3/mysql/postgres
 			Sources  []string // DSN

--- a/internal/wirex/injector.go
+++ b/internal/wirex/injector.go
@@ -36,6 +36,7 @@ func InitDB(ctx context.Context) (*gorm.DB, func(), error) {
 
 	db, err := gormx.New(gormx.Config{
 		Debug:        cfg.Debug,
+		PrepareStmt:  cfg.PrepareStmt,
 		DBType:       cfg.Type,
 		DSN:          cfg.DSN,
 		MaxLifetime:  cfg.MaxLifetime,

--- a/pkg/gormx/gorm.go
+++ b/pkg/gormx/gorm.go
@@ -28,6 +28,7 @@ type ResolverConfig struct {
 
 type Config struct {
 	Debug        bool
+	PrepareStmt  bool
 	DBType       string // mysql/postgres/sqlite3
 	DSN          string
 	MaxLifetime  int
@@ -61,7 +62,8 @@ func New(cfg Config) (*gorm.DB, error) {
 			TablePrefix:   cfg.TablePrefix,
 			SingularTable: true,
 		},
-		Logger: logger.Discard,
+		Logger:      logger.Discard,
+		PrepareStmt: cfg.PrepareStmt,
 	}
 
 	if cfg.Debug {


### PR DESCRIPTION
启用 GORM 的 PrepareStmt 配置项以默认使用语句缓存